### PR TITLE
Remove hiring content

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-## Hi there 👋
+# Kharagpur Open Source Society
 
 <!--
 
@@ -13,13 +13,13 @@
 
 ![KOSS Cover](https://imgur.com/xKFP30Y.png)
 
-# Who are We?
+# Who are we?
 
-* We are a bunch of Open Source enthusiasts, who love to share the culture of OSS. Through events and workshops, we try to share the different aspects of Software Engineering.
+* We are a bunch of Open Source enthusiasts, who love to share the culture of programming and OSS. Through events and workshops, we try to share the different aspects of Software Engineering.
   
-* We love to work on new ideas and projects, though we don't promote it from KOSS by default. You can find involvement of KOSS members in MetaKGP, developing on a project which is helpful for the KGP Community. You can also find members who are motivated enough to work on funky ideas and projects, which might range to solve a real-world issue, to create a project for banter, to help out folks learn a new language or framework.
+* While we don't work on project ideas as a group, you can find KOSS members involved in MetaKGP, developing a project helpful to the KGP Community. You can also find members who are motivated to work on funky ideas and projects, which might range from solving a real-world issue, to creating a project for banter or helping out folks learn a new language or framework.
   
-* We inculcate an environment, where each of us work on anything that we might want to learn, and in return you would get fantastic mentors on the subject matter. Want to learn Frontend? Hop on to a call with [xypnox](https://github.com/xypnox); Want to learn more about Shell Scripting? [grapheo12](https://github.com/grapheo12) is informative to teach you. Infact, each one of us have carved their own specialization and have had their fair share of experience to guide you, so KOSS members are the goto folks.
+* We nurture an environment where each of us can work on anything that we might want to learn, and in turn, become a fantastic mentor on the subject. Want to learn Frontend? Hop on to a call with [xypnox](https://github.com/xypnox); Want to learn more about Shell Scripting? Ping [grapheo12](https://github.com/grapheo12) is informative to teach you. In fact, each one of us has carved their own specialization and has had their fair share of experience to guide you, so KOSS members are the goto folks.
 
   
 ## What do we do?  
@@ -36,7 +36,7 @@
 
 * We don't coach people to crack GSoC.
        
-* We are not a research based society. We work on Software Development problems, and we use code to ease our approach to achieve our goals. We work on developing projects, which might be helpful for achieving our goals, but all in all, we dont develop projects for the sake of it. We use custom written projects to achieve our goals.
+* We are not a research based society. We work on Software Development problems and we use code to ease our approach to achieve our goals. We work on developing projects, which might be helpful for achieving our goals, but all in all, we dont develop projects for the sake of it. We use custom written projects to achieve our goals.
 
 
 ## We are also at

--- a/profile/README.md
+++ b/profile/README.md
@@ -17,9 +17,9 @@
 
 * We are a bunch of Open Source enthusiasts, who love to share the culture of programming and OSS. Through events and workshops, we try to share the different aspects of Software Engineering.
   
-* While we don't work on project ideas as a group, you can find KOSS members involved in MetaKGP, developing a project helpful to the KGP Community. You can also find members who are motivated to work on funky ideas and projects, which might range from solving a real-world issue, to creating a project for banter or helping out folks learn a new language or framework.
+* While we don't work on project ideas as a group, you can find KOSS members involved in [MetaKGP](https://github.com/metakgp), developing a project helpful to the KGP Community. You can also find members who are motivated to work on funky ideas and projects, which might range from solving a real-world issue, to creating a project for banter or helping out folks learn a new language or framework.
   
-* We nurture an environment where each of us can work on anything that we might want to learn, and in turn, become a fantastic mentor on the subject. Want to learn Frontend? Hop on to a call with [xypnox](https://github.com/xypnox); Want to learn more about Shell Scripting? Ping [grapheo12](https://github.com/grapheo12) is informative to teach you. In fact, each one of us has carved their own specialization and has had their fair share of experience to guide you, so KOSS members are the goto folks.
+* We nurture an environment where each of us can work on anything that we might want to learn, and in turn, become a fantastic mentor on the subject. Each one of us has carved their own specialization and has had their fair share of experience to guide you, so KOSS members are the goto folks.
 
   
 ## What do we do?  
@@ -34,7 +34,7 @@
 
 ## What do we NOT do?
 
-* We don't coach people to crack GSoC.
+* We don't train people to crack any coding competitions or hackathons.
        
 * We are not a research based society. We work on Software Development problems and we use code to ease our approach to achieve our goals. We work on developing projects, which might be helpful for achieving our goals, but all in all, we dont develop projects for the sake of it. We use custom written projects to achieve our goals.
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -15,17 +15,14 @@
 
 # Who are We?
 
-* We are a bunch of Open Source enthusiasts, who love to share the culture of OSS. Through events and workshops, we try to share the different aspects of Software Engineering, and onboard folks with the basic understanding and literacy of Software Development.
+* We are a bunch of Open Source enthusiasts, who love to share the culture of OSS. Through events and workshops, we try to share the different aspects of Software Engineering.
   
 * We love to work on new ideas and projects, though we don't promote it from KOSS by default. You can find involvement of KOSS members in MetaKGP, developing on a project which is helpful for the KGP Community. You can also find members who are motivated enough to work on funky ideas and projects, which might range to solve a real-world issue, to create a project for banter, to help out folks learn a new language or framework.
   
-* We inculcate an environment, where each of us work on anything that we might want to learn, and in return you would get fantastic mentors on the subject matter. Want to learn Frontend? Hop on to a call with [xypnox](https://github.com/xypnox); Want to learn more about Shell Scripting? [grapheo12](https://github.com/grapheo12) is informative to teach you. Infact, each one of us have carved their own specialization and have had their fair share of experience to guide you, so the KOSS members are the goto folks.
+* We inculcate an environment, where each of us work on anything that we might want to learn, and in return you would get fantastic mentors on the subject matter. Want to learn Frontend? Hop on to a call with [xypnox](https://github.com/xypnox); Want to learn more about Shell Scripting? [grapheo12](https://github.com/grapheo12) is informative to teach you. Infact, each one of us have carved their own specialization and have had their fair share of experience to guide you, so KOSS members are the goto folks.
 
-* We value culture over technical prowess; You might be a rockstar developer, and quite adept with your skills, but we love to host people, who are empathic, a team member whom you can trust upon, and whom you can depend on. KOSS provides ample of mentoring to folks who want to curate their skills in a field of their choice, and in return they are expected to pass the baton. People having a sound skills is a bonus, but we value your soft-skills more than your technical knowledge.
   
 ## What do we do?  
-
-> Thanks for asking this question! This sets up the expectation from KOSS as a society :) 
  
 * We are a college society to spread the culture of Open Source.
 
@@ -40,10 +37,6 @@
 * We don't coach people to crack GSoC. That is not our main objective as a society. If you want to join KOSS because of this sole reason, you are better suited to ask previous GSoCers about the same.
        
 * We are not a research based society. We work on Software Development problems, and we use code to ease our approach to achieve our goals. We work on developing projects, which might be helpful for achieving our goals, but all in all, we dont develop projects for the sake of it. We use custom written projects to achieve our goals.
-
-* Avoid joining KOSS if you want a POR. Effectively, KOSS might not add any value to your resume, if you are looking to join KOSS for the purpose of POR. KOSS helps you to develop good Software Engineering skills and build up the empathy and understanding of Software Engineering. This might not make sense, if your career goals don't match with the above, you would benefit a lot, if you are in for the learning, especially Software Enggineering and OSS.
-
-* Don't join KOSS if you find the workload quite less. KOSS mostly uses digital medium to catch up with the members, and people might confuse this with low workload. We make sure that the new members are given ample of time to choose and work on their skills of choice, and this involve different amount of workload for everyone. Ultimately, you would be wasting your time in KOSS, if learning the skills of OSS and Software Engineering was something you don't ought to do. We love to keep things relaxed, so that folks work on their skills at their own pace.
 
 
 ## We are also at

--- a/profile/README.md
+++ b/profile/README.md
@@ -24,8 +24,6 @@
   
 ## What do we do?  
  
-* We are a college society to spread the culture of Open Source.
-
 * We conduct workshops and events to share the culture of OSS with the KGP folks.
 
 * We conduct [KWoC(Kharagpur Winter of Code)](https://kwoc.kossiitkgp.org/) which is a winter long contribution program for new contributors.

--- a/profile/README.md
+++ b/profile/README.md
@@ -34,7 +34,7 @@
 
 ## What do we NOT do?
 
-* We don't coach people to crack GSoC. That is not our main objective as a society. If you want to join KOSS because of this sole reason, you are better suited to ask previous GSoCers about the same.
+* We don't coach people to crack GSoC.
        
 * We are not a research based society. We work on Software Development problems, and we use code to ease our approach to achieve our goals. We work on developing projects, which might be helpful for achieving our goals, but all in all, we dont develop projects for the sake of it. We use custom written projects to achieve our goals.
 


### PR DESCRIPTION
The current content seems to be in the context of onboarding new mwmbers. In this page, we can perhaps be more generalized and just talk about who we are. Please let me know if this sounds okay.